### PR TITLE
titles for deck data

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ $ npm run dev
 ## Built With
 * ReactJS, Redux, Node, Express, Babel, Webpack...
 
+## Titles in the Deck Data
+* Javascript: Core Concepts
+* Javascript: Common built-in methods
+* Javascript: Common event handlers
+* Javascript: Design patterns
+* CSS
+* CSS: Pseudo-classes
+* CSS: Animations
+* CSS3 - Flexbox
+* HTML
+* React
+* Angular
+* Javascript: 3
+* Vue
+* DOM Fundamentals
+* ES6
+* JavaScript: Intermediate
+* SASS: Basics
+* Webpack Basic Concepts
+* jQuery: Basics
+* General Front End Questions
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details

--- a/src/data/file.js
+++ b/src/data/file.js
@@ -1,3 +1,28 @@
+//
+// Titles in the Decks
+//
+// Javascript: Core Concepts
+// Javascript: Common built-in methods
+// Javascript: Common event handlers
+// Javascript: Design patterns
+// CSS
+// CSS: Pseudo-classes
+// CSS: Animations
+// CSS3 - Flexbox
+// HTML
+// React
+// Angular
+// Javascript: 3
+// Vue
+// DOM Fundamentals
+// ES6
+// JavaScript: Intermediate
+// SASS: Basics
+// Webpack Basic Concepts
+// jQuery: Basics
+// General Front End Questions
+//
+
 export function deckData() {
   return [
     {


### PR DESCRIPTION
Titles were parsed from the deck data using

```bash
egrep '^\s*title' src/data/file.js | sed -e 's/^[^"]*"\([^"]*\).*/\1/'
```
The result was placed at the top of `file.js` (within comments), and a new section was added near the bottom of the README.md with the same data.